### PR TITLE
(Isssue #11) Use str instead of basestring for py3 compatibility

### DIFF
--- a/csvvalidator.py
+++ b/csvvalidator.py
@@ -344,7 +344,7 @@ class CSVValidator(object):
 
         """
 
-        if isinstance(key, basestring):
+        if isinstance(key, str):
             assert key in self._field_names, 'unexpected field name: %s' % key
         else:
             for f in key:
@@ -706,7 +706,7 @@ class CSVValidator(object):
         for key, code, message in self._unique_checks:
             value = None
             values = unique_sets[key]
-            if isinstance(key, basestring): # assume key is a field name
+            if isinstance(key, str): # assume key is a field name
                 fi = self._field_names.index(key)
                 if fi >= len(r):
                     continue


### PR DESCRIPTION
"The builtin basestring abstract type was removed. Use str instead. The
str and bytes types don't have functionality enough in common to warrant
a shared base class. The 2to3 tool (see below) replaces every occurrence
of basestring with str."